### PR TITLE
Resolve Coroutine Handling Error in Tool Output Submission

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN pip install --no-cache-dir poetry \
 COPY poetry.lock /env/poetry.lock
 COPY pyproject.toml /env/pyproject.toml
 
-RUN cd /env && poetry install --no-dev
+RUN cd /env && poetry lock --no-update && poetry install --only main
 
 EXPOSE 8086
 

--- a/app/services/run/run.py
+++ b/app/services/run/run.py
@@ -193,20 +193,19 @@ class RunService:
         return db_run
 
     @staticmethod
-    def get_in_progress_run_step(*, run_id, session: Session) -> RunStep:
-        run_step = (
-            session.execute(
-                select(RunStep)
-                .where(RunStep.run_id == run_id)
-                .where(RunStep.type == "tool_calls")
-                .where(RunStep.status == "in_progress")
-                .order_by(desc(RunStep.created_at))
-            )
-            .scalars()
-            .one_or_none()
+    async def get_in_progress_run_step(*, run_id: str, session: AsyncSession):
+        result = await session.execute(
+            select(RunStep)
+            .where(RunStep.run_id == run_id)
+            .where(RunStep.type == "tool_calls")
+            .where(RunStep.status == "in_progress")
+            .order_by(desc(RunStep.created_at))
         )
+        run_step = result.scalars().one_or_none()
+
         if not run_step:
             raise ResourceNotFoundError("run_step not found or not in progress")
+
         return run_step
 
     @staticmethod


### PR DESCRIPTION
### Description
This pull request addresses the coroutine handling error encountered when submitting tool outputs, as detailed in issue #61. The modifications include:

- **Updated Coroutine Management:** The `get_in_progress_run_step` method within `RunService` has been adjusted to properly utilize `await` with SQLAlchemy's async session operations. This ensures that database queries are correctly awaited before their results are manipulated.
- **Poetry Command Adjustments in Dockerfile:** Updated the Docker commands to adhere to the new poetry syntax, which resolves deprecation warnings and lock file issues. Specifically, the `poetry install --no-dev` command was replaced with `poetry lock --no-update` followed by `poetry install --only main`.